### PR TITLE
allow each request attribute rewrite

### DIFF
--- a/source/net/gyokuro/core/application.ceylon
+++ b/source/net/gyokuro/core/application.ceylon
@@ -88,7 +88,6 @@ shared class Application<T>(
         }
         value endpoints = ArrayList<HttpEndpoint|WebSocketEndpoint>();
         
-        endpoints.add(RequestDispatcher(controllers, filter, renderer, transformers).endpoint());
         if (exists modulesPath) {
             endpoints.add(RepositoryEndpoint(modulesPath));
         }
@@ -121,6 +120,8 @@ shared class Application<T>(
                 onBinary = wsHandler.onBinary;
             });
         }
+        
+        endpoints.add(RequestDispatcher(controllers, filter, renderer, transformers).endpoint());
         
         value s = server = newServer(endpoints);
         s.addListener(statusListener);

--- a/source/net/gyokuro/core/internal/dispatcher.ceylon
+++ b/source/net/gyokuro/core/internal/dispatcher.ceylon
@@ -71,13 +71,12 @@ shared class RequestDispatcher<T>([String, Package|{Object*}]? packageToScan,
         annotationScanner.scanControllers(contextRoot, controllers);
     }
     
-    object routerMatcher extends Matcher() {
-        shared actual Boolean matches(String path)
-                => router.canHandlePath(path);
+    object everyPath extends Matcher() {
+        shared actual Boolean matches(String path) => true;
     }
     
     shared Endpoint endpoint() {
-        return Endpoint(routerMatcher, dispatch,
+        return Endpoint(everyPath, dispatch,
             { options, get, head, post, put, delete, trace, connect, patch });
     }
     


### PR DESCRIPTION
Hi. While writing sort of HTTP/FTP proxy I noticed gyokuro has no wildcard route support (as i.e. /ftp/*). I tried to abuse filters for that, only to notice those are invoked only for registered paths. So this PR installs RequestDispatcher as last Endpoint to serve as kitchen sink. Filter will finally stand its doc: "A filter applied to each incoming request before it is dispatched..." (well, all but Repository requests). BR, sam_